### PR TITLE
Fix/simbrief time sync

### DIFF
--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -282,8 +282,14 @@ def set_future_time_internal(future_time_input, current_sim_time):
             if future_time_input.tzinfo is None:
                 future_time_input = future_time_input.replace(tzinfo=timezone.utc)
 
-            # Convert real-world time to simulator time
-            future_time_candidate = convert_real_world_time_to_sim_time(future_time_input)
+            if USE_SIMBRIEF_ADJUSTED_TIME:
+                # Adjust SimBrief's time to align with simulator time
+                future_time_candidate = convert_real_world_time_to_sim_time(future_time_input)
+                print("DEBUG: Adjusted SimBrief time to simulator time:", future_time_candidate)
+            else:
+                # Use SimBrief's real-world time directly
+                future_time_candidate = future_time_input
+                print("DEBUG: Using SimBrief real-world time directly:", future_time_candidate)
 
             # Validate that the future time is after the current simulator time
             if future_time_candidate <= current_sim_time:

--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -543,12 +543,20 @@ def load_simbrief_future_time():
 # Start the time update loop
 def periodic_simbrief_update():
     """
-    Periodically update the future time using SimBrief data.
+    Periodically update the future time using SimBrief data if no user-set time exists.
     """
-    if not is_future_time_manually_set:
+    global future_time, is_future_time_manually_set
+
+    # Reload SimBrief only if no user-set time and no valid future time exists
+    if not is_future_time_manually_set and future_time is None:
+        print("DEBUG: No user-set time or future time exists. Reloading SimBrief data.")
         load_simbrief_future_time()
+    else:
+        print("DEBUG: Skipping SimBrief reload; user-set time or future time already exists.")
+
     # Schedule the next update
     root.after(SIMBRIEF_UPDATE_INTERVAL, periodic_simbrief_update)
+
 
 # --- Drag functionality ---
 is_moving = False

--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -314,7 +314,7 @@ def set_future_time():
     Prompt the user to set a future countdown time based on Sim Time.
     If no input is provided, use SimBrief time based on the global `USE_SIMBRIEF_ADJUSTED_TIME` flag.
     """
-    global future_time
+    global future_time, is_future_time_manually_set
     try:
         # Get current simulator datetime
         current_sim_time = get_simulator_datetime()
@@ -323,6 +323,8 @@ def set_future_time():
         # Prompt the user to enter the future time in HHMM format
         prompt_message = f"Enter future time based on Sim Time (HHMM)\nCurrent Sim Time: {sim_time_str}"
         future_time_input = simpledialog.askstring("Input", prompt_message, initialvalue=last_entered_time, parent=root)
+
+        is_future_time_manually_set = True
 
         # If user provides input, use it
         if future_time_input and set_future_time_internal(future_time_input, current_sim_time):

--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -45,7 +45,7 @@ DISPLAY_TEMPLATE = (
 # VAR(Altitude:, get_altitude, tomato)
 
 # Configurable Variables
-SIMBRIEF_USERNAME = "cgtrout"  # Enter your SimBrief username here to enable automatic lookup of flight arrival times for the countdown timer. Leave blank to disable SimBrief integration.
+SIMBRIEF_USERNAME = ""  # Enter your SimBrief username here to enable automatic lookup of flight arrival times for the countdown timer. Leave blank to disable SimBrief integration.
 USE_SIMBRIEF_ADJUSTED_TIME = False  # Set to True for simulator-adjusted time, False for real-world time
 
 alpha_transparency_level = 0.95  # Set transparency (0.0 = fully transparent, 1.0 = fully opaque)

--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -52,7 +52,7 @@ alpha_transparency_level = 0.95  # Set transparency (0.0 = fully transparent, 1.
 WINDOW_TITLE = "Simulator Time"
 DARK_BG = "#000000"
 FONT = ("Helvetica", 16)
-UPDATE_INTERVAL = 500  # in milliseconds (1 second)
+UPDATE_INTERVAL = 1000  # in milliseconds (1 second)
 RECONNECT_INTERVAL = 1000  # in milliseconds (5 seconds)
 SIMBRIEF_UPDATE_INTERVAL = 15000  # in milliseconds (15 seconds)
 PADDING_X = 20  # Horizontal padding for each label

--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone, timedelta
 import os
 import json
 import requests
+import time
 
 # Print initial message
 print("custom_status_bar: Close this window to close status bar")
@@ -122,8 +123,18 @@ def get_time_to_future():
         if future_time is None:
             return "00:00:00"
 
-        # Get the current simulator datetime
-        current_sim_time = get_simulator_datetime()
+        # Retry loop for getting simulator datetime
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                current_sim_time = get_simulator_datetime()
+                break  # If successful, exit the retry loop
+            except Exception as e:
+                if attempt < max_retries - 1:
+                    time.sleep(0.25)  # Wait before retrying
+                else:
+                    print("DEBUG: Max retries reached. Skipping update for this cycle.")
+                    return "00:00:00"
 
         # Ensure both times are timezone-aware (UTC)
         if future_time.tzinfo is None:

--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -143,15 +143,16 @@ def get_time_to_future():
         if sim_rate:
             try:
                 sim_rate = float(sim_rate)  # Ensure the simulation rate is numeric
-                if sim_rate > 0:
-                    adjusted_seconds = remaining_time.total_seconds() / sim_rate
-                else:
-                    adjusted_seconds = remaining_time.total_seconds()
+                adjusted_seconds = remaining_time.total_seconds() / sim_rate
             except ValueError:
-                # If conversion fails, default to 1.0
+                # If conversion fails, default to 1.0 and log the issue
+                print(f"DEBUG: Simulation rate conversion failed; using unadjusted time.")
                 adjusted_seconds = remaining_time.total_seconds()
         else:
+            # Handle missing simulation rate
+            print("DEBUG: Simulation rate unavailable; using unadjusted time.")
             adjusted_seconds = remaining_time.total_seconds()
+
 
         # Format the adjusted remaining time as HH:MM:SS
         hours, remainder = divmod(adjusted_seconds, 3600)

--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -44,7 +44,7 @@ DISPLAY_TEMPLATE = (
 # VAR(Altitude:, get_altitude, tomato)
 
 # Configurable Variables
-SIMBRIEF_USERNAME = ""  # Enter your SimBrief username here to enable automatic lookup of flight arrival times for the countdown timer. Leave blank to disable SimBrief integration.
+SIMBRIEF_USERNAME = "cgtrout"  # Enter your SimBrief username here to enable automatic lookup of flight arrival times for the countdown timer. Leave blank to disable SimBrief integration.
 USE_SIMBRIEF_ADJUSTED_TIME = False  # Set to True for simulator-adjusted time, False for real-world time
 
 alpha_transparency_level = 0.95  # Set transparency (0.0 = fully transparent, 1.0 = fully opaque)
@@ -551,12 +551,9 @@ def periodic_simbrief_update():
     if not is_future_time_manually_set and future_time is None:
         print("DEBUG: No user-set time or future time exists. Reloading SimBrief data.")
         load_simbrief_future_time()
-    else:
-        print("DEBUG: Skipping SimBrief reload; user-set time or future time already exists.")
 
     # Schedule the next update
     root.after(SIMBRIEF_UPDATE_INTERVAL, periodic_simbrief_update)
-
 
 # --- Drag functionality ---
 is_moving = False


### PR DESCRIPTION
Fix multiple issues related to simbrief handling.

- Only sets simbrief time once, but if change to simbrief is detected, it will reload timer value
- Pause now properly supported - time will stop correctly.
- USE_SIMBRIEF_ADJUSTED_TIME should now correctly handle in all cases.
- Now correctly handles user input on timer.

Also changed simconnected handling - will try a few times -- occationally the sim doesn't return values so this will make simconnect lookups more robust.
