### PR TITLE
Added Feature - autoclose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Data/Community_Install/chrisaut-toolbar-printouts/html_ui/InGamePanels/chrisaut-
 Data/Community_Install/chrisaut-toolbar-printouts/html_ui/InGamePanels/chrisaut-toolbar-printouts/CustomPanel.html
 Data/Community_Install/chrisaut-toolbar-printouts/html_ui/icons/toolbar/ICON_TOOLBAR_CHRISAUT_PRINTOUTS_PANEL.svg
 /Data/Fonts
+application_log.txt


### PR DESCRIPTION
- This allows launcher script to close when C App is closed
- Uses pipe to handle shut down
- Pipe name is provided by argument to launcher script.
- If no argument is provided this custom shutdown logic is bypassed (mainly to support running launcher directly in VS Code).
- Logs shutdown information related to this to "shutdown_log.txt"

- Could easily be extended to provide launch options for MSFS-PyScriptManager to change this behavior, but at moment is locked to new behavior.