### PR TITLE
Launcher - terminate_process_tree - close io streams

### DIFF
--- a/Launcher/LauncherScript/Launcher.py
+++ b/Launcher/LauncherScript/Launcher.py
@@ -670,6 +670,12 @@ class ProcessTracker:
                 print(f"[INFO] Terminating process for Tab ID {tab_id} (PID {process.pid}).")
                 self._terminate_process_tree(process.pid)
 
+            # Close the process's I/O streams
+            if process.stdout:
+                process.stdout.close()
+            if process.stderr:
+                process.stderr.close()
+
             # Signal threads to stop
             self.queues[tab_id]["stop_event"].set()
             print(f"[INFO] Stop event set for Tab ID: {tab_id}")


### PR DESCRIPTION
When testing 2024 and closing 2024, it caused a hang in the launcher app.

I have not yet been able to determine the exact cause of this, so there is a good chance this change will not resolve the issue.  

The last test of 2024 did not cause a hang though.  If any issues remain, I'll need to identify a way to comprehensively log everything all scripts are doing in context to the launcher app.