### PR TITLE
Launcher - shutdown / std out changes

### DIFF
--- a/Launcher/LauncherScript/Launcher_test.py
+++ b/Launcher/LauncherScript/Launcher_test.py
@@ -5,6 +5,7 @@ import time
 import socket
 from pathlib import Path
 from Launcher import ScriptLauncherApp, ScriptTab
+import tkinter as tk
 
 def get_python_pids():
     """Get all active Python process PIDs."""
@@ -16,27 +17,19 @@ def start_network_server(host="127.0.0.1", port=65432, stop_event=None):
         print(f"[SERVER] Connected to {addr}")
         try:
             while not stop_event.is_set():
-                # Simulate random disconnections
-                if random.random() < 0.1:  # 10% chance to disconnect
+                if random.random() < 0.1:
                     print(f"[SERVER] Simulating disconnection for {addr}")
                     conn.close()
                     return
-
-                # Simulate random delays
-                if random.random() < 0.2:  # 20% chance of delay
-                    delay = random.uniform(0.5, 2.0)  # Delay between 0.5 to 2 seconds
+                if random.random() < 0.2:
+                    delay = random.uniform(0.5, 2.0)
                     print(f"[SERVER] Simulating delay of {delay:.2f}s for {addr}")
                     time.sleep(delay)
-
-                # Receive data
                 data = conn.recv(1024)
                 if not data:
                     print(f"[SERVER] Client {addr} disconnected")
                     return
-
-                # Echo the data back
                 conn.sendall(data)
-
         except (ConnectionResetError, BrokenPipeError):
             print(f"[SERVER] Connection to {addr} lost.")
         finally:
@@ -47,7 +40,6 @@ def start_network_server(host="127.0.0.1", port=65432, stop_event=None):
         server.bind((host, port))
         server.listen()
         print(f"[SERVER] Listening on {host}:{port}")
-
         try:
             while not stop_event.is_set():
                 server.settimeout(1)
@@ -57,13 +49,10 @@ def start_network_server(host="127.0.0.1", port=65432, stop_event=None):
                     client_thread.start()
                 except socket.timeout:
                     continue
-        except KeyboardInterrupt:
-            print("[SERVER] Server shutting down.")
         finally:
             server.close()
 
     threading.Thread(target=server_thread, daemon=True).start()
-
 
 def create_test_script(script_path, server_address):
     """Create a test script that connects to the server and runs indefinitely."""
@@ -85,127 +74,93 @@ def network_worker(server_address):
                     time.sleep(1)
         except Exception as e:
             print("[CLIENT] Connection error:", e)
-            time.sleep(2)  # Retry after a short delay
+            time.sleep(2)
 
 if __name__ == "__main__":
     network_worker({server_address})
-    """
+"""
     script_path.write_text(script_content)
-
 
 def cleanup_test_script(script_path):
     """Remove the test script."""
     try:
-        script_path.unlink()  # Delete the file
+        script_path.unlink(missing_ok=True)
     except FileNotFoundError:
         pass
 
+def terminate_process_using_file(file_path):
+    """Terminate any process using the given file."""
+    print(f"[DEBUG] Attempting to terminate processes using {file_path}...")
+    for proc in psutil.process_iter(attrs=["open_files"]):
+        try:
+            open_files = proc.info.get("open_files", [])
+            if open_files is None:
+                continue
+            if any(str(file_path) in str(f.path) for f in open_files):
+                print(f"[DEBUG] Terminating process {proc.pid}")
+                proc.terminate()
+                proc.wait(timeout=5)
+        except psutil.TimeoutExpired:
+            print(f"[WARNING] Process {proc.pid} did not terminate in time.")
+        except psutil.AccessDenied:
+            print(f"[ERROR] Access denied for process {proc.pid}.")
+        except psutil.NoSuchProcess:
+            print(f"[ERROR] Process {proc.pid} does not exist.")
+        except Exception as e:
+            print(f"[ERROR] Could not terminate process {proc.pid}: {e}")
 
 def fuzz_test_launcher(scripts_dir, server_address=("127.0.0.1", 65432), duration=30):
     """Run a fuzz test on the ScriptLauncherApp with network interactions."""
-    # Step 1: Capture Python processes before
     initial_pids = get_python_pids()
     print(f"[TEST] Initial Python processes: {initial_pids}")
 
-    # Step 2: Start the network server
     stop_event = threading.Event()
     start_network_server(server_address[0], server_address[1], stop_event)
 
-    # Step 3: Create the test script
-    test_script = scripts_dir / "test_script.py"
-    create_test_script(test_script, server_address)
-    print(f"[TEST] Test script created: {test_script}")
+    test_script_path = scripts_dir / "test_script.py"
+    create_test_script(test_script_path, server_address)
+    print(f"[TEST] Test script created: {test_script_path}")
 
-    # Step 4: Start the ScriptLauncherApp in a separate thread
-    root = None
-    app = None
+    root = tk.Tk()
+    app = ScriptLauncherApp(root)
 
-    def start_app():
-        nonlocal root, app
-        from tkinter import Tk
-        root = Tk()
-        app = ScriptLauncherApp(root)
-        root.mainloop()
-
-    app_thread = threading.Thread(target=start_app, daemon=True)
-    app_thread.start()
-
-    # Allow time for the app to initialize
-    while not app:
-        time.sleep(1)
-
-    print("[TEST] App started. Opening Performance Monitor...")
-    
-    # Step 5: Open the Performance Monitor tab
-    perf_tab_id = None
-    try:
-        perf_tab_id = app.tab_manager.generate_tab_id()  # Generate a unique ID for the PerfTab
-        app.open_performance_metrics_tab()  # Open the performance monitoring tab
-    except Exception as e:
-        print(f"[TEST] Error opening Performance Monitor: {e}")
-
-    print("[TEST] Performance Monitor tab opened. Beginning fuzz testing...")
-
-    # Step 6: Randomized addition and closure of script tabs
-    start_time = time.time()
-    open_tabs = []
-    tab_counter = 0
-
-    try:
-        while time.time() - start_time < duration:
-            action = random.choice(["add", "close"])
-
-            if action == "add" or not open_tabs:
-                # Add a new script tab
-                print("[TEST] Adding a new script tab...")
-                app.load_script(test_script)
-                tab_id = app.tab_manager.current_tab_id  # Get the most recently added tab ID
-                open_tabs.append(tab_id)
-                print(f"[TEST] Added tab {tab_id}.")
-            elif action == "close" and open_tabs:
-                # Close a random tab
-                tab_id = random.choice(open_tabs)
-                print(f"[TEST] Closing tab {tab_id}...")
-                app.tab_manager.close_tab(tab_id)
-                open_tabs.remove(tab_id)
-
-            # Wait for a random interval between actions
-            time.sleep(random.uniform(0.5, 2))
-
-        print("[TEST] Fuzz testing completed.")
-
-    except KeyboardInterrupt:
-        print("[TEST] Fuzz testing interrupted by user.")
-
-    finally:
-        # Step 7: Cleanup
-        print("[TEST] Cleaning up...")
-        for tab_id in open_tabs:
+    def process_queue():
+        """Process cleanup queue after fuzz testing."""
+        print("[TEST] Cleaning up resources...")
+        for tab_id in range(1, app.tab_manager.current_tab_id + 1):
             print(f"[TEST] Closing remaining tab {tab_id}...")
             app.tab_manager.close_tab(tab_id)
-
-        if perf_tab_id is not None:
-            print("[TEST] Closing Performance Monitor tab...")
-            app.tab_manager.close_tab(perf_tab_id)
-
-        cleanup_test_script(test_script)
+        terminate_process_using_file(test_script_path)
+        cleanup_test_script(test_script_path)
         print("[TEST] Test script cleaned up.")
-        root.quit()
-        app_thread.join()
-        stop_event.set()
-        print("[TEST] Launcher app and server stopped.")
 
-        # Step 8: Capture Python processes after
-        final_pids = get_python_pids()
-        print(f"[TEST] Final Python processes: {final_pids}")
+        # Use the app's shutdown mechanism with a callback
+        def after_shutdown():
+            print("[TEST] Shutdown complete.")
+            # Final PID check
+            final_pids = get_python_pids()
+            print(f"[TEST] Final Python processes: {final_pids}")
 
-        # Step 9: Ensure all new PIDs are terminated
-        remaining_pids = final_pids - initial_pids
-        if remaining_pids:
-            print(f"[WARNING] The following Python processes were not terminated: {remaining_pids}")
-        else:
-            print("[TEST] All Python processes started by the app were terminated successfully.")
+            remaining_pids = final_pids - initial_pids
+            if remaining_pids:
+                print(f"[WARNING] The following Python processes were not terminated: {remaining_pids}")
+            else:
+                print("[TEST] All Python processes terminated successfully.")
+
+        app.on_close(callback=after_shutdown)
+
+    def start_fuzz_test():
+        print("[TEST] Starting fuzz testing...")
+        start_time = time.time()
+        while time.time() - start_time < duration:
+            app.load_script(test_script_path)
+            time.sleep(random.uniform(0.5, 1.5))
+        print("[TEST] Fuzz testing completed.")
+        root.after(100, process_queue)  # Ensure process_queue is called after mainloop completes
+
+    threading.Thread(target=start_fuzz_test, daemon=True).start()
+    root.mainloop()
 
 if __name__ == "__main__":
-    scripts_dir = Path(__file__).resolve().parent / "Scripts"  # Directory for the test script
-    fuzz_test_launcher(scripts_dir, duration=30)  # Run the test for 30 seconds
+    scripts_dir = Path(__file__).resolve().parent / "Scripts"
+    fuzz_test_launcher(scripts_dir, duration=30)


### PR DESCRIPTION
This update makes changes on Launcher.py with main goal of improving potential thread issues by using .after method of Tkinter.  This schedules tasks to occur on main thread which eliminates needs for locks in certain contexts.

Also made some other changes such as following some warnings given by pylint tool and further improvements to shutdown/termination of PID.

- TabManager - use tkinter after to avoid potential threading issues
- ProcessTracker - add 'scheduler' to allow synchronization through Tkinter
- _insert_stdout - make sure tab still exists on write
- _read_output - move stream.close to finally block
- _read_output - check stop even in while loop rather than in for loop
- generalize stdout / stderr callbacks
- _terminate_process_tree - improve process tree termination logic with enhanced error handling and orphan cleanup
- remove unused functions
- fix pylint warnings
- on_close - use root.after on destroy to preserve shut down order of operations
- Launcher_test - fix to work with latest changes
- Add custom callback to on_close to support testing