### PR TITLE
custom_status_bar - The zero value for SimConnect variables should not be considered failures to acquire the value

### DIFF
--- a/Scripts/custom_status_bar.py
+++ b/Scripts/custom_status_bar.py
@@ -331,7 +331,7 @@ def get_simconnect_value(variable_name: str, default_value: Any = "N/A",
     add_to_cache(variable_name, default_value)
     for _ in range(retries):
         value = check_cache(variable_name)
-        if value and value != default_value:
+        if value is not None and value != default_value:
             return value
         time.sleep(retry_interval)
 


### PR DESCRIPTION
SimConnect variables can and do have zero values (e.g. floats such as speed, booleans such as engine combustion status), and a zero value should not be considered as a failure to acquire a value.

Fixes https://github.com/cgtrout/MSFS-PyScriptManager/issues/50