### PR TITLE
Fix pygame warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ application_log.txt
 shutdown_log.txt
 profile_output.html
 detailed_state_log.txt
+Launcher/launcher.ini

--- a/Launcher/LauncherScript/Launcher.py
+++ b/Launcher/LauncherScript/Launcher.py
@@ -1733,9 +1733,31 @@ class ProcessTracker:
                 name=f"DispatcherStdout-{tab_id}"
             ).start()
 
+            # Warning redirect for pkg_resource warning (pygame)
+            # This is a issue present in current version of pygame that hasn't yet been fixed
+            warn_followup = {"pending": False}
+
+            def _forward_pkg_resources_warning(line):
+                # Emit to launcher.c (stdout) and log, but do not show in script tab.
+                print(line, end="")
+                logger.warning(line.rstrip("\n"))
+
+            def _stderr_wrapper(text):
+                if "pkg_resources is deprecated as an API" in text:
+                    warn_followup["pending"] = True
+                    _forward_pkg_resources_warning(text)
+                    return
+                if warn_followup["pending"]:
+                    if "from pkg_resources import" in text:
+                        _forward_pkg_resources_warning(text)
+                        warn_followup["pending"] = False
+                        return
+                    warn_followup["pending"] = False
+                stderr_callback(text)
+
             threading.Thread(
                 target=self._dispatch_queue,
-                args=(stderr_queue, stderr_callback, stop_event),
+                args=(stderr_queue, _stderr_wrapper, stop_event),
                 daemon=True,
                 name=f"DispatcherStderr-{tab_id}"
             ).start()

--- a/Launcher/launcher.ini
+++ b/Launcher/launcher.ini
@@ -5,4 +5,4 @@
 # Path to the Python installation directory (relative to project root)
 # The launcher will look for python.exe and pythonw.exe in this directory
 # VS Code.exe will be located in the parent directory
-PythonDir=
+PythonDir=WinPython\WPy64-313110\python

--- a/Launcher/requirements.txt
+++ b/Launcher/requirements.txt
@@ -5,6 +5,9 @@ keyboard
 pygetwindow
 requests
 matplotlib
+
+# Pin older version of setuptools to avoid pkg_resources deprecation warning from pygame
+setuptools<81
 pygame
 Pillow
 SimConnect


### PR DESCRIPTION
## Suppress pygame pkg_resources warnings

Route pygame pkg_resources deprecation warning (emitted by setuptools when pygame imports pkg_resources) to launcher console instead of script tabs; warning is upstream and not caused by this project.