### PR TITLE
Py 3.14 compat

### DIFF
--- a/Launcher/LauncherApp/Source/Launcher.c
+++ b/Launcher/LauncherApp/Source/Launcher.c
@@ -575,13 +575,23 @@ int run_script(const char *pythonPath, const char *scriptPath)
     return exitCode;
 }
 
-int main()
+int main(int argc, char **argv)
 {
     char pythonPathBuffer[512];
     const char *pythonPath = NULL;
+    int forceSelectPython = 0;
+
+    // Simple CLI parsing
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "--pick") == 0)
+        {
+            forceSelectPython = 1;
+        }
+    }
 
     // --- Try the path from launcher.ini first ---
-    if (readPythonPathFromIni(pythonPathBuffer, sizeof(pythonPathBuffer)))
+    if (!forceSelectPython && readPythonPathFromIni(pythonPathBuffer, sizeof(pythonPathBuffer)))
     {
         // Validate that pythonw.exe actually exists at the configured path
         DWORD attrs = GetFileAttributes(pythonPathBuffer);

--- a/Launcher/requirements.txt
+++ b/Launcher/requirements.txt
@@ -1,3 +1,5 @@
+--prefer-binary
+
 numpy
 psutil
 ttkthemes
@@ -8,8 +10,15 @@ matplotlib
 
 # Pin older version of setuptools to avoid pkg_resources deprecation issue
 setuptools<81
-pygame
-Pillow
+
+# pygame wheels don't cover Python 3.14+; use pygame-ce which ships cp314 wheels
+pygame==2.6.1; python_version < "3.14"
+pygame-ce==2.5.6; python_version >= "3.14"
+
+# Pillow: force a cp314-compatible wheel on Python 3.14+
+Pillow>=12.1.0; python_version >= "3.14"
+Pillow>=10.4.0; python_version < "3.14"
+
 SimConnect
 pywin32
 pywinpty

--- a/Tests/import_checker.py
+++ b/Tests/import_checker.py
@@ -83,19 +83,46 @@ def try_import_any(import_names: list[str]) -> tuple[bool, str | None]:
 
 
 def parse_requirements(requirements_path: Path) -> list[str]:
-    """Parse requirements.txt and extract package names."""
+    """Parse requirements.txt and extract package names, respecting environment markers."""
     if not requirements_path.exists():
         return []
+
+    # Import packaging for marker evaluation
+    try:
+        from packaging.markers import Marker, InvalidMarker
+    except ImportError:
+        Marker = None
+        InvalidMarker = Exception
 
     packages = []
     with open(requirements_path, "r") as f:
         for line in f:
             line = line.strip()
-            if not line or line.startswith("#"):
+            # Skip empty lines, comments, and pip flags
+            if not line or line.startswith("#") or line.startswith("-"):
                 continue
+
+            # Check for environment marker (PEP 508)
+            marker_str = None
+            if ";" in line:
+                line, marker_str = line.split(";", 1)
+                marker_str = marker_str.strip()
+
+            # Extract package name (strip version specifiers and extras)
             package = line.split("==")[0].split(">=")[0].split("<=")[0].split("<")[0].split(">")[0].split("[")[0].strip()
-            if package:
-                packages.append(package)
+            if not package:
+                continue
+
+            # Evaluate environment marker if present
+            if marker_str and Marker is not None:
+                try:
+                    marker = Marker(marker_str)
+                    if not marker.evaluate():
+                        continue  # Skip package - marker doesn't match current environment
+                except InvalidMarker:
+                    pass  # Invalid marker syntax, include package anyway
+
+            packages.append(package)
     return packages
 
 

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,12 @@ Currently, **most of the included scripts will detect Simulator state**.  Howeve
 - The launcher EXE is provided for convenience, but you can also launch the script manually.  It is also possible to launch the script "/Launcher/Launcher.py" from "WinPython/WinPython Command Prompt.exe" if you prefer to not launch from the EXE.  The exe can be built by launching "Build.bat" in "\Launcher\LauncherApp" as the "TCC" C-Compiler is included(https://bellard.org/tcc/).
 - You can easily create your own scripts and run them as well.  Note that if you need to add any libraries use the "WinPython/WinPython Command Prompt.exe" and run the "pip" command from here to add a library to the WinPython directory.
 - I recommend using [Visual Studio Code](https://code.visualstudio.com/download) for editing the scripts.  The built in "Edit" button will open the selected script in VS Code if it is installed.
+
+## WinPython Notes
 - Uses WinPython to allow standalone installation - https://github.com/winpython
+- Now supports multiple versions of WinPython.  To switch versions run "MSFS-PyScriptManager.exe --pick" (this will bring up a menu to allow you to switch to other installed versions).
+- Extract new versions of WinPython to /WinPython directory then run pick command above to switch to a new installed version.
+- The launcher will use the "requirements.txt" file in /Launcher to ensure all required modules are installed through pip.
 
 ## Additional Credits
 - Icon used for Launcher: [JoyPixels Emojione](https://github.com/joypixels/emojione) (MIT License)


### PR DESCRIPTION
## Python 3.14 Compatibility Work
- Changed requirements.txt file so that appropriate versions are loaded of PyGame and Pillow.
- Fixed issue with import_checker.
- Updated readme.md for WinPython changes.