### PR TITLE
Link chrisaut-toolbar-printouts directly into git project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,6 @@ Settings/*
 *.script_group
 todo.txt
 WinPython.7z
-Launcher/LauncherApp/Lib/7z/7za.dll
-Launcher/LauncherApp/Lib/7z/7zxa.dll
-Data/Community_Install/chrisaut-toolbar-printouts/*
-
 application_log.txt
 shutdown_log.txt
 profile_output.html

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = Lib/MSFSPythonSimConnectMobiFlightExtension
 	url = https://github.com/cgtrout/MSFSPythonSimConnectMobiFlightExtension.git
 	branch = multi-client-support
+[submodule "Data/Community_Install"]
+	path = Data/Community_Install
+	url = https://github.com/chrisaut/chrisaut-toolbar-printouts.git
+	branch = master


### PR DESCRIPTION
Properly integrate chrisaut-toolbar-printouts into project (as a linked submodule) so it automatically imports for users who pull directly from Github.

https://github.com/chrisaut/chrisaut-toolbar-printouts