### PR TITLE
Better input

### DIFF
--- a/Launcher/LauncherScript/process_tracker.py
+++ b/Launcher/LauncherScript/process_tracker.py
@@ -284,6 +284,7 @@ class ProcessTracker:
                     input_data: str | None = input_queue.get(timeout=1)  # Block until input is available
                     if input_data is None:  # Sentinel for EOF
                         break
+                    logger.debug("stdin write: %r", input_data)
                     stdin.write(input_data)
                     stdin.flush()  # Ensure immediate delivery to the subprocess
                 except queue.Empty:

--- a/Launcher/LauncherScript/tabs/script_tab.py
+++ b/Launcher/LauncherScript/tabs/script_tab.py
@@ -28,6 +28,219 @@ if TYPE_CHECKING:
     from process_tracker import ProcessTracker
 
 
+class LineEditor:
+    """Manages line-editing buffer and echo for stdin input."""
+
+    def __init__(self, text_widget: tk.Text):
+        self.text_widget = text_widget
+        self._buffer: list[str] = []
+        self._cursor: int = 0
+        self._mark_name = "input_echo"
+
+    def _log_buffer(self, operation: str) -> None:
+        """Log current buffer state for debugging."""
+        buffer_str = "".join(self._buffer)
+        print(f"[LineEditor.{operation}] buffer='{buffer_str}' cursor={self._cursor} len={len(self._buffer)}")
+
+    def insert_char(self, char: str) -> None:
+        """Insert a printable character at cursor position."""
+        print(f"[LineEditor.insert_char] BEFORE: char='{char}'")
+        self._log_buffer("insert_char.before")
+        self._buffer.insert(self._cursor, char)
+        self._cursor += 1
+        self._log_buffer("insert_char.after")
+        self._update_echo()
+
+    def backspace(self) -> None:
+        """Delete character before cursor."""
+        print(f"[LineEditor.backspace] BEFORE:")
+        self._log_buffer("backspace.before")
+        if self._cursor > 0:
+            self._cursor -= 1
+            del self._buffer[self._cursor]
+            self._log_buffer("backspace.after")
+            self._update_echo()
+        else:
+            print(f"[LineEditor.backspace] SKIPPED: cursor already at 0")
+
+    def delete(self) -> None:
+        """Delete character at cursor."""
+        print(f"[LineEditor.delete] BEFORE:")
+        self._log_buffer("delete.before")
+        if self._cursor < len(self._buffer):
+            del self._buffer[self._cursor]
+            self._log_buffer("delete.after")
+            self._update_echo()
+        else:
+            print(f"[LineEditor.delete] SKIPPED: cursor at end")
+
+    def move_left(self) -> None:
+        if self._cursor > 0:
+            self._cursor -= 1
+            self._update_echo()
+
+    def move_right(self) -> None:
+        if self._cursor < len(self._buffer):
+            self._cursor += 1
+            self._update_echo()
+
+    def move_home(self) -> None:
+        self._cursor = 0
+        self._update_echo()
+
+    def move_end(self) -> None:
+        self._cursor = len(self._buffer)
+        self._update_echo()
+
+    def handle_click(self, event) -> str:
+        """Handle mouse click to position cursor in the echo buffer."""
+        if not self._buffer or self._mark_name not in self.text_widget.mark_names():
+            return "break"
+
+        # Get the click position
+        click_index = self.text_widget.index(f"@{event.x},{event.y}")
+        mark_index = self.text_widget.index(self._mark_name)
+
+        # Calculate offset from mark to click position
+        click_pos = float(click_index)
+        mark_pos = float(mark_index)
+
+        # If click is before the mark or after the buffer, ignore
+        if click_pos < mark_pos:
+            return "break"
+
+        # Get the line and column of both positions
+        click_line, click_col = map(int, click_index.split('.'))
+        mark_line, mark_col = map(int, mark_index.split('.'))
+
+        # If on the same line, calculate character offset
+        if click_line == mark_line:
+            offset = click_col - mark_col
+            # Clamp to buffer length
+            self._cursor = min(max(0, offset), len(self._buffer))
+            self._update_echo()
+
+        return "break"
+
+    def get_line(self) -> str:
+        """Get the current line, finalize echo, and clear buffer."""
+        line = "".join(self._buffer)
+        self._finalize_echo()
+        return line
+
+    def clear(self) -> None:
+        """Clear the buffer without finalizing echo."""
+        self._buffer.clear()
+        self._cursor = 0
+
+    def has_content(self) -> bool:
+        """Check if buffer has any content."""
+        return bool(self._buffer)
+
+    def _update_echo(self) -> None:
+        """Redraw the current line at the end of the text widget."""
+        buffer_str = "".join(self._buffer)
+        print(f"[LineEditor._update_echo] ENTRY: buffer='{buffer_str}'")
+
+        if not self.text_widget.winfo_exists():
+            print(f"[LineEditor._update_echo] EXIT: widget doesn't exist")
+            return
+
+        # Log ALL content before we start
+        all_content_before = self.text_widget.get("1.0", tk.END)
+        print(f"[LineEditor._update_echo] Widget full content BEFORE: {all_content_before!r}")
+
+        # If mark exists, check if it's in the right place (should be on the last line)
+        # If not, unset it and we'll recreate it
+        if self._mark_name in self.text_widget.mark_names():
+            mark_pos = self.text_widget.index(self._mark_name)
+            end_pos = self.text_widget.index(tk.END)
+            mark_line = int(float(mark_pos))
+            end_line = int(float(end_pos))
+            print(f"[LineEditor._update_echo] Mark at {mark_pos} (line {mark_line}), END at {end_pos} (line {end_line})")
+
+            # If mark is not on the last line (or line before due to trailing newline), it's stale
+            if mark_line < end_line - 1:
+                print(f"[LineEditor._update_echo] Mark is stale (not on last line), unsetting it")
+                self.text_widget.mark_unset(self._mark_name)
+
+        # Now create or use the mark
+        if self._mark_name not in self.text_widget.mark_names():
+            # No mark - create it at the end of the last non-empty line
+            # Get the last line content
+            last_line_start = self.text_widget.index("end-1c linestart")
+            last_line_content = self.text_widget.get(last_line_start, "end-1c")
+            print(f"[LineEditor._update_echo] Last line content: {last_line_content!r}")
+
+            # Set mark at the very end (before the trailing newline that tk.END includes)
+            self.text_widget.mark_set(self._mark_name, "end-1c")
+            self.text_widget.mark_gravity(self._mark_name, "left")
+            mark_pos = self.text_widget.index(self._mark_name)
+            print(f"[LineEditor._update_echo] Created mark at {mark_pos}")
+
+        mark_pos = self.text_widget.index(self._mark_name)
+        print(f"[LineEditor._update_echo] Using mark at position: {mark_pos}")
+
+        # Get current content between mark and END
+        current_echo = self.text_widget.get(self._mark_name, tk.END)
+        print(f"[LineEditor._update_echo] Content from mark to END: {current_echo!r}")
+
+        # Delete old echo
+        self.text_widget._orig_delete(self._mark_name, tk.END)
+        print(f"[LineEditor._update_echo] Deleted from mark to END")
+
+        # Check content after delete
+        all_content_after_delete = self.text_widget.get("1.0", tk.END)
+        print(f"[LineEditor._update_echo] Widget full content AFTER DELETE: {all_content_after_delete!r}")
+
+        # Insert new buffer
+        self.text_widget._orig_insert(tk.END, buffer_str)
+        print(f"[LineEditor._update_echo] Inserted buffer at END: {buffer_str!r}")
+
+        # Position the cursor at the correct location in the buffer
+        # The mark is at the start of the echo, cursor should be mark + buffer cursor offset
+        cursor_pos = f"{self._mark_name}+{self._cursor}c"
+        self.text_widget.mark_set("insert", cursor_pos)
+        print(f"[LineEditor._update_echo] Set cursor to position: {cursor_pos} (buffer cursor={self._cursor})")
+
+        # Check final content
+        all_content_final = self.text_widget.get("1.0", tk.END)
+        print(f"[LineEditor._update_echo] Widget full content FINAL: {all_content_final!r}")
+
+        self.text_widget.see("insert")  # Scroll to show the cursor
+        print(f"[LineEditor._update_echo] EXIT")
+
+    def _finalize_echo(self) -> None:
+        """Lock in the submitted line: append newline, remove mark, clear buffer."""
+        if not self.text_widget.winfo_exists():
+            return
+
+        self.text_widget._orig_insert(tk.END, "\n")
+        if self._mark_name in self.text_widget.mark_names():
+            self.text_widget.mark_unset(self._mark_name)
+        self.text_widget.see(tk.END)
+
+        self._buffer.clear()
+        self._cursor = 0
+
+    def preserve_echo_for_output(self) -> str:
+        """Strip echo if present, return echo text.
+        Caller MUST call restore_echo() after inserting output."""
+        if not self._buffer or self._mark_name not in self.text_widget.mark_names():
+            return ""
+
+        echo_text = "".join(self._buffer)
+        self.text_widget._orig_delete(self._mark_name, tk.END)
+        return echo_text
+
+    def restore_echo(self, echo_text: str) -> None:
+        """Restore echo (if any)."""
+        if echo_text:
+            self.text_widget.mark_set(self._mark_name, tk.END)
+            self.text_widget.mark_gravity(self._mark_name, "left")
+            self.text_widget._orig_insert(tk.END, echo_text)
+
+
 class ScriptTab(Tab):
     """Represents one running script in a tab"""
     def __init__(
@@ -49,6 +262,10 @@ class ScriptTab(Tab):
 
         self._ansi_parser: AnsiParser = AnsiParser()
 
+        # Line-editing state (created after text_widget in build_content)
+        self._line_editor: LineEditor | None = None
+        self._processing_key: bool = False  # Re-entrance guard
+
         # Text buffer
         self.text_buffer: list[tuple[str, AnsiStyle]] = []
         self.is_flushing: bool = False
@@ -68,9 +285,36 @@ class ScriptTab(Tab):
             bg=TEXT_WIDGET_BG_COLOR,
             fg=TEXT_WIDGET_FG_COLOR,
             insertbackground=TEXT_WIDGET_INSERT_COLOR,
-            font=self.font_normal
+            font=self.font_normal,
         )
         self.text_widget.pack(side="left", expand=True, fill="both")
+
+        # Initialize line editor for stdin input management
+        self._line_editor = LineEditor(self.text_widget)
+
+        # Block paste/cut operations (we only allow our controlled input)
+        self.text_widget.bind("<<Cut>>", lambda _: "break")
+        self.text_widget.bind("<<Paste>>", lambda _: "break")
+        self.text_widget.bind("<<Clear>>", lambda _: "break")
+        self.text_widget.bind("<<PasteSelection>>", lambda _: "break")
+
+        # Override the Text widget's insert and delete methods to prevent direct modification
+        # Store original methods so we can still use them internally
+        self.text_widget._orig_insert = self.text_widget.insert
+        self.text_widget._orig_delete = self.text_widget.delete
+
+        def readonly_insert(*args, **kwargs):
+            """Blocked insert - only our code should insert via _orig_insert"""
+            print(f"[BLOCKED] Attempted insert: args={args}")
+            return
+
+        def readonly_delete(*args, **kwargs):
+            """Blocked delete - only our code should delete via _orig_delete"""
+            print(f"[BLOCKED] Attempted delete: args={args}")
+            return
+
+        self.text_widget.insert = readonly_insert
+        self.text_widget.delete = readonly_delete
 
         # Create a styled ttk.Scrollbar and attach it to the text widget
         scrollbar = ttk.Scrollbar(
@@ -128,8 +372,12 @@ class ScriptTab(Tab):
         )
         stop_button.pack(side="left", padx=5, pady=2)
 
-        # Bind F5 to reload
-        self.text_widget.bind("<F5>", lambda event: self.reload_script())
+        # Intercept all keys on the text widget so default Text insertion is suppressed;
+        # line-editing and stdin forwarding are handled by _handle_text_key / _process_key.
+        self.text_widget.bind("<Key>", self._handle_text_key)
+
+        # Handle mouse clicks to position cursor in the input buffer
+        self.text_widget.bind("<Button-1>", lambda e: self._line_editor.handle_click(e))
 
         # Check metadata for any commands
         # This allows custom buttons to be assigned for each script
@@ -278,6 +526,10 @@ class ScriptTab(Tab):
     def _safe_insert_segments(self, segments: list[tuple[str, AnsiStyle]]) -> None:
         """Safely insert text segments with colors and bold styles into the text widget."""
         try:
+            # If the user is mid-line, strip the echo, insert output, then restore it
+            # so that script output always appears *before* the partially-typed line.
+            echo_text = self._line_editor.preserve_echo_for_output()
+
             for segment, style in segments:
                 color: str | None = style.get("color")  # Extract the color
                 bold: bool = style.get("bold", False)  # Extract bold
@@ -285,10 +537,12 @@ class ScriptTab(Tab):
                 if color or bold:
                     # Ensure the tag exists for this combination of color and bold
                     tag = self.ensure_tag(color=color, bold=bold)
-                    self.text_widget.insert(tk.END, segment, tag)
+                    self.text_widget._orig_insert(tk.END, segment, tag)
                 else:
                     # Insert plain text with no formatting
-                    self.text_widget.insert(tk.END, segment)
+                    self.text_widget._orig_insert(tk.END, segment)
+
+            self._line_editor.restore_echo(echo_text)
 
             self.text_widget.see(tk.END)  # Scroll to the end
         except TclError as e:
@@ -300,7 +554,12 @@ class ScriptTab(Tab):
         """Safely insert text into the text widget"""
         try:
             if self.text_widget and self.text_widget.winfo_exists():
-                self.text_widget.insert(tk.END, text)
+                echo_text = self._line_editor.preserve_echo_for_output()
+
+                self.text_widget._orig_insert(tk.END, text)
+
+                self._line_editor.restore_echo(echo_text)
+
                 self.text_widget.see(tk.END)  # Scroll to the end
         except TclError as e:
             print(f"[WARNING] _safe_insert: TclError encountered while writing to the widget: {e}")
@@ -349,11 +608,13 @@ class ScriptTab(Tab):
 
         def _reload() -> None:
             self.process_tracker.terminate_process(self.tab_id)
+            if self._line_editor:
+                self._line_editor.clear()
 
             # Clear the text widget (output page)
             if clear_text is True:
                 if self.text_widget and self.text_widget.winfo_exists():
-                    self.text_widget.delete('1.0', tk.END)
+                    self.text_widget._orig_delete('1.0', tk.END)
 
             self.run_script()
 
@@ -362,35 +623,143 @@ class ScriptTab(Tab):
     def stop_script(self) -> None:
         """Stop the running of the script"""
         self.process_tracker.terminate_process(self.tab_id)
+        if self._line_editor:
+            self._line_editor.clear()
+
+    # ------------------------------------------------------------------
+    # Key handling  —  line-editing buffer
+    # ------------------------------------------------------------------
+    # Raw keystrokes are never written to the pipe individually.  Instead
+    # they are accumulated in _input_buffer.  Backspace / Delete / arrows
+    # edit the buffer locally; only pressing Enter flushes the finished
+    # line (+ "\n") to stdin_queue.  The current buffer contents are
+    # echoed at the end of the text widget using a named mark so that
+    # script output arriving while the user is mid-line can be inserted
+    # *before* the echo without clobbering it.
+    # ------------------------------------------------------------------
+
+    def _handle_text_key(self, event: tk.Event[tk.Misc]) -> str | None:
+        """Widget-level <Key> binding.  Returns 'break' to suppress the
+        default Text-widget character-insertion behaviour."""
+        keysym: str = event.keysym
+        char: str = event.char or ""
+
+        print(f"[_handle_text_key] ENTRY: keysym={keysym!r} char={char!r} widget={event.widget}")
+
+        # Let Ctrl/Alt combos propagate (Ctrl+C copy, etc.)
+        # but block Ctrl+V — we don't want pasted text silently added
+        # to the widget outside of the buffer.
+        if event.state & 0x04:  # Ctrl held
+            result = "break" if keysym in ("v", "V") else None
+            print(f"[_handle_text_key] EXIT: Ctrl combo, returning {result!r}")
+            return result
+
+        # Modifier-only presses: ignore
+        if keysym in ("Control_L", "Control_R", "Alt_L", "Alt_R",
+                      "Shift_L", "Shift_R", "Super_L", "Super_R"):
+            print(f"[_handle_text_key] EXIT: modifier-only key")
+            return None
+
+        # F5  →  reload (replaces the old <F5> widget binding)
+        if keysym == "F5":
+            print(f"[_handle_text_key] F5 detected, reloading script")
+            self.reload_script()
+            return "break"
+
+        print(f"[_handle_text_key] Calling _process_key")
+        self._process_key(event)
+        print(f"[_handle_text_key] EXIT: returning 'break'")
+        return "break"
 
     def handle_keypress(self, event: tk.Event[tk.Misc]) -> None:
-        """Handle keypress events."""
+        """Global-binding fallback called by app.on_key_press when focus
+        is *not* on the text widget (e.g. a button in the tab)."""
+        keysym: str = event.keysym
+        char: str = event.char or ""
+
+        print(f"[handle_keypress] ENTRY: keysym={keysym!r} char={char!r} widget={event.widget} is_active={self.is_active}")
+
         if not self.is_active:
+            print(f"[handle_keypress] EXIT: tab not active")
+            return
+        # Root's <Key> binding fires for all key events on Windows. If the event
+        # originated from text_widget, its binding already handled it → skip.
+        if self.text_widget and event.widget is self.text_widget:
+            print(f"[handle_keypress] EXIT: event from text_widget, skipping")
+            return
+        if event.keysym == "F5":
+            print(f"[handle_keypress] F5 detected, reloading script")
+            self.reload_script()
             return
 
-        key: str = event.char or ""  # Get the character, default to empty for non-character keys
-        if key == "\r":
-            key = "\n"  # Handle Enter key
+        print(f"[handle_keypress] Calling _process_key")
+        self._process_key(event)
+        print(f"[handle_keypress] EXIT")
 
-        # Add input to the queue
+    def _process_key(self, event: tk.Event[tk.Misc]) -> None:
+        """Core line-editing logic — shared by widget and global paths."""
+        keysym: str = event.keysym
+        char: str = event.char or ""
+
+        print(f"[_process_key] ENTRY: keysym={keysym!r} char={char!r} _processing_key={self._processing_key}")
+
+        if self._processing_key:
+            print(f"[_process_key] EXIT: re-entrance guard blocked")
+            return  # Already processing a key, prevent re-entrance
+
+        if not self._line_editor:
+            print(f"[_process_key] EXIT: no line editor")
+            return
+
+        process_info = self.process_tracker.processes.get(self.tab_id)
+        if not process_info:
+            print(f"[_process_key] EXIT: no process info")
+            return
+
+        self._processing_key = True
+        print(f"[_process_key] SET _processing_key=True")
         try:
-            # Retrieve the correct process info
-            process_info = self.process_tracker.processes.get(self.tab_id)
-            if not process_info:
-                return
+            if keysym == "BackSpace":
+                print(f"[_process_key] Processing BackSpace")
+                self._line_editor.backspace()
 
-            # Access the stdin_queue
-            stdin_queue = process_info["stdin_queue"]
+            elif keysym == "Delete":
+                print(f"[_process_key] Processing Delete")
+                self._line_editor.delete()
 
-            # Add the key to the queue
-            stdin_queue.put_nowait(key)  # Non-blocking enqueue
+            elif keysym == "Left":
+                print(f"[_process_key] Processing Left")
+                self._line_editor.move_left()
 
-        except queue.Full:
-            self.insert_output("[WARNING] Input queue is full. Input dropped.\n")
-        except KeyError as e:
-            self.insert_output(f"[ERROR] Missing key in process info: {e}\n")
-        except Exception as e:
-            self.insert_output(f"[ERROR] Unexpected error: {e}\n")
+            elif keysym == "Right":
+                print(f"[_process_key] Processing Right")
+                self._line_editor.move_right()
+
+            elif keysym == "Home":
+                print(f"[_process_key] Processing Home")
+                self._line_editor.move_home()
+
+            elif keysym == "End":
+                print(f"[_process_key] Processing End")
+                self._line_editor.move_end()
+
+            elif keysym == "Return":
+                print(f"[_process_key] Processing Return")
+                line = self._line_editor.get_line()
+                print(f"[_process_key] Sending line to stdin: {line!r}")
+                try:
+                    process_info["stdin_queue"].put_nowait(line + "\n")
+                except queue.Full:
+                    self.insert_output("[WARNING] Input queue is full. Input dropped.\n")
+
+            elif char and char.isprintable():
+                print(f"[_process_key] Processing printable char: {char!r}")
+                self._line_editor.insert_char(char)
+            else:
+                print(f"[_process_key] No action taken for this key")
+        finally:
+            self._processing_key = False
+            print(f"[_process_key] EXIT: SET _processing_key=False")
 
     def on_tab_activated(self) -> None:
         if self.text_widget and self.text_widget.winfo_exists():

--- a/Launcher/LauncherScript/tabs/script_tab.py
+++ b/Launcher/LauncherScript/tabs/script_tab.py
@@ -92,10 +92,10 @@ class LineEditor:
         self._cursor = len(self._buffer)
         self._update_echo()
 
-    def handle_click(self, event) -> str:
+    def handle_click(self, event) -> str | None:
         """Handle mouse click to position cursor in the echo buffer."""
         if not self._buffer or self._mark_name not in self.text_widget.mark_names():
-            return "break"
+            return None  # No buffer active, allow normal selection
 
         # Get the click position
         click_index = self.text_widget.index(f"@{event.x},{event.y}")
@@ -105,9 +105,9 @@ class LineEditor:
         click_pos = float(click_index)
         mark_pos = float(mark_index)
 
-        # If click is before the mark or after the buffer, ignore
+        # If click is before the mark, allow normal selection (selecting output text)
         if click_pos < mark_pos:
-            return "break"
+            return None
 
         # Get the line and column of both positions
         click_line, click_col = map(int, click_index.split('.'))
@@ -119,8 +119,10 @@ class LineEditor:
             # Clamp to buffer length
             self._cursor = min(max(0, offset), len(self._buffer))
             self._update_echo()
+            return "break"  # We handled cursor positioning in the input buffer
 
-        return "break"
+        # Click is after the buffer but not on the same line, allow selection
+        return None
 
     def get_line(self) -> str:
         """Get the current line, finalize echo, and clear buffer."""

--- a/Launcher/LauncherScript/tabs/script_tab.py
+++ b/Launcher/LauncherScript/tabs/script_tab.py
@@ -27,6 +27,13 @@ from config import (
 if TYPE_CHECKING:
     from process_tracker import ProcessTracker
 
+DEBUG_PRINT = False
+
+
+def _debug_print(message: str) -> None:
+    if DEBUG_PRINT:
+        print(message)
+
 
 class LineEditor:
     """Manages line-editing buffer and echo for stdin input."""
@@ -40,11 +47,11 @@ class LineEditor:
     def _log_buffer(self, operation: str) -> None:
         """Log current buffer state for debugging."""
         buffer_str = "".join(self._buffer)
-        print(f"[LineEditor.{operation}] buffer='{buffer_str}' cursor={self._cursor} len={len(self._buffer)}")
+        _debug_print(f"[LineEditor.{operation}] buffer='{buffer_str}' cursor={self._cursor} len={len(self._buffer)}")
 
     def insert_char(self, char: str) -> None:
         """Insert a printable character at cursor position."""
-        print(f"[LineEditor.insert_char] BEFORE: char='{char}'")
+        _debug_print(f"[LineEditor.insert_char] BEFORE: char='{char}'")
         self._log_buffer("insert_char.before")
         self._buffer.insert(self._cursor, char)
         self._cursor += 1
@@ -53,7 +60,7 @@ class LineEditor:
 
     def backspace(self) -> None:
         """Delete character before cursor."""
-        print(f"[LineEditor.backspace] BEFORE:")
+        _debug_print(f"[LineEditor.backspace] BEFORE:")
         self._log_buffer("backspace.before")
         if self._cursor > 0:
             self._cursor -= 1
@@ -61,18 +68,18 @@ class LineEditor:
             self._log_buffer("backspace.after")
             self._update_echo()
         else:
-            print(f"[LineEditor.backspace] SKIPPED: cursor already at 0")
+            _debug_print(f"[LineEditor.backspace] SKIPPED: cursor already at 0")
 
     def delete(self) -> None:
         """Delete character at cursor."""
-        print(f"[LineEditor.delete] BEFORE:")
+        _debug_print(f"[LineEditor.delete] BEFORE:")
         self._log_buffer("delete.before")
         if self._cursor < len(self._buffer):
             del self._buffer[self._cursor]
             self._log_buffer("delete.after")
             self._update_echo()
         else:
-            print(f"[LineEditor.delete] SKIPPED: cursor at end")
+            _debug_print(f"[LineEditor.delete] SKIPPED: cursor at end")
 
     def move_left(self) -> None:
         if self._cursor > 0:
@@ -142,15 +149,15 @@ class LineEditor:
     def _update_echo(self) -> None:
         """Redraw the current line at the end of the text widget."""
         buffer_str = "".join(self._buffer)
-        print(f"[LineEditor._update_echo] ENTRY: buffer='{buffer_str}'")
+        _debug_print(f"[LineEditor._update_echo] ENTRY: buffer='{buffer_str}'")
 
         if not self.text_widget.winfo_exists():
-            print(f"[LineEditor._update_echo] EXIT: widget doesn't exist")
+            _debug_print(f"[LineEditor._update_echo] EXIT: widget doesn't exist")
             return
 
         # Log ALL content before we start
         all_content_before = self.text_widget.get("1.0", tk.END)
-        print(f"[LineEditor._update_echo] Widget full content BEFORE: {all_content_before!r}")
+        _debug_print(f"[LineEditor._update_echo] Widget full content BEFORE: {all_content_before!r}")
 
         # If mark exists, check if it's in the right place (should be on the last line)
         # If not, unset it and we'll recreate it
@@ -159,11 +166,11 @@ class LineEditor:
             end_pos = self.text_widget.index(tk.END)
             mark_line = int(float(mark_pos))
             end_line = int(float(end_pos))
-            print(f"[LineEditor._update_echo] Mark at {mark_pos} (line {mark_line}), END at {end_pos} (line {end_line})")
+            _debug_print(f"[LineEditor._update_echo] Mark at {mark_pos} (line {mark_line}), END at {end_pos} (line {end_line})")
 
             # If mark is not on the last line (or line before due to trailing newline), it's stale
             if mark_line < end_line - 1:
-                print(f"[LineEditor._update_echo] Mark is stale (not on last line), unsetting it")
+                _debug_print(f"[LineEditor._update_echo] Mark is stale (not on last line), unsetting it")
                 self.text_widget.mark_unset(self._mark_name)
 
         # Now create or use the mark
@@ -172,45 +179,45 @@ class LineEditor:
             # Get the last line content
             last_line_start = self.text_widget.index("end-1c linestart")
             last_line_content = self.text_widget.get(last_line_start, "end-1c")
-            print(f"[LineEditor._update_echo] Last line content: {last_line_content!r}")
+            _debug_print(f"[LineEditor._update_echo] Last line content: {last_line_content!r}")
 
             # Set mark at the very end (before the trailing newline that tk.END includes)
             self.text_widget.mark_set(self._mark_name, "end-1c")
             self.text_widget.mark_gravity(self._mark_name, "left")
             mark_pos = self.text_widget.index(self._mark_name)
-            print(f"[LineEditor._update_echo] Created mark at {mark_pos}")
+            _debug_print(f"[LineEditor._update_echo] Created mark at {mark_pos}")
 
         mark_pos = self.text_widget.index(self._mark_name)
-        print(f"[LineEditor._update_echo] Using mark at position: {mark_pos}")
+        _debug_print(f"[LineEditor._update_echo] Using mark at position: {mark_pos}")
 
         # Get current content between mark and END
         current_echo = self.text_widget.get(self._mark_name, tk.END)
-        print(f"[LineEditor._update_echo] Content from mark to END: {current_echo!r}")
+        _debug_print(f"[LineEditor._update_echo] Content from mark to END: {current_echo!r}")
 
         # Delete old echo
         self.text_widget._orig_delete(self._mark_name, tk.END)
-        print(f"[LineEditor._update_echo] Deleted from mark to END")
+        _debug_print(f"[LineEditor._update_echo] Deleted from mark to END")
 
         # Check content after delete
         all_content_after_delete = self.text_widget.get("1.0", tk.END)
-        print(f"[LineEditor._update_echo] Widget full content AFTER DELETE: {all_content_after_delete!r}")
+        _debug_print(f"[LineEditor._update_echo] Widget full content AFTER DELETE: {all_content_after_delete!r}")
 
         # Insert new buffer
         self.text_widget._orig_insert(tk.END, buffer_str)
-        print(f"[LineEditor._update_echo] Inserted buffer at END: {buffer_str!r}")
+        _debug_print(f"[LineEditor._update_echo] Inserted buffer at END: {buffer_str!r}")
 
         # Position the cursor at the correct location in the buffer
         # The mark is at the start of the echo, cursor should be mark + buffer cursor offset
         cursor_pos = f"{self._mark_name}+{self._cursor}c"
         self.text_widget.mark_set("insert", cursor_pos)
-        print(f"[LineEditor._update_echo] Set cursor to position: {cursor_pos} (buffer cursor={self._cursor})")
+        _debug_print(f"[LineEditor._update_echo] Set cursor to position: {cursor_pos} (buffer cursor={self._cursor})")
 
         # Check final content
         all_content_final = self.text_widget.get("1.0", tk.END)
-        print(f"[LineEditor._update_echo] Widget full content FINAL: {all_content_final!r}")
+        _debug_print(f"[LineEditor._update_echo] Widget full content FINAL: {all_content_final!r}")
 
         self.text_widget.see("insert")  # Scroll to show the cursor
-        print(f"[LineEditor._update_echo] EXIT")
+        _debug_print(f"[LineEditor._update_echo] EXIT")
 
     def _finalize_echo(self) -> None:
         """Lock in the submitted line: append newline, remove mark, clear buffer."""
@@ -307,12 +314,12 @@ class ScriptTab(Tab):
 
         def readonly_insert(*args, **kwargs):
             """Blocked insert - only our code should insert via _orig_insert"""
-            print(f"[BLOCKED] Attempted insert: args={args}")
+            _debug_print(f"[BLOCKED] Attempted insert: args={args}")
             return
 
         def readonly_delete(*args, **kwargs):
             """Blocked delete - only our code should delete via _orig_delete"""
-            print(f"[BLOCKED] Attempted delete: args={args}")
+            _debug_print(f"[BLOCKED] Attempted delete: args={args}")
             return
 
         self.text_widget.insert = readonly_insert
@@ -646,31 +653,31 @@ class ScriptTab(Tab):
         keysym: str = event.keysym
         char: str = event.char or ""
 
-        print(f"[_handle_text_key] ENTRY: keysym={keysym!r} char={char!r} widget={event.widget}")
+        _debug_print(f"[_handle_text_key] ENTRY: keysym={keysym!r} char={char!r} widget={event.widget}")
 
         # Let Ctrl/Alt combos propagate (Ctrl+C copy, etc.)
         # but block Ctrl+V — we don't want pasted text silently added
         # to the widget outside of the buffer.
         if event.state & 0x04:  # Ctrl held
             result = "break" if keysym in ("v", "V") else None
-            print(f"[_handle_text_key] EXIT: Ctrl combo, returning {result!r}")
+            _debug_print(f"[_handle_text_key] EXIT: Ctrl combo, returning {result!r}")
             return result
 
         # Modifier-only presses: ignore
         if keysym in ("Control_L", "Control_R", "Alt_L", "Alt_R",
                       "Shift_L", "Shift_R", "Super_L", "Super_R"):
-            print(f"[_handle_text_key] EXIT: modifier-only key")
+            _debug_print(f"[_handle_text_key] EXIT: modifier-only key")
             return None
 
         # F5  →  reload (replaces the old <F5> widget binding)
         if keysym == "F5":
-            print(f"[_handle_text_key] F5 detected, reloading script")
+            _debug_print(f"[_handle_text_key] F5 detected, reloading script")
             self.reload_script()
             return "break"
 
-        print(f"[_handle_text_key] Calling _process_key")
+        _debug_print(f"[_handle_text_key] Calling _process_key")
         self._process_key(event)
-        print(f"[_handle_text_key] EXIT: returning 'break'")
+        _debug_print(f"[_handle_text_key] EXIT: returning 'break'")
         return "break"
 
     def handle_keypress(self, event: tk.Event[tk.Misc]) -> None:
@@ -679,89 +686,89 @@ class ScriptTab(Tab):
         keysym: str = event.keysym
         char: str = event.char or ""
 
-        print(f"[handle_keypress] ENTRY: keysym={keysym!r} char={char!r} widget={event.widget} is_active={self.is_active}")
+        _debug_print(f"[handle_keypress] ENTRY: keysym={keysym!r} char={char!r} widget={event.widget} is_active={self.is_active}")
 
         if not self.is_active:
-            print(f"[handle_keypress] EXIT: tab not active")
+            _debug_print(f"[handle_keypress] EXIT: tab not active")
             return
         # Root's <Key> binding fires for all key events on Windows. If the event
         # originated from text_widget, its binding already handled it → skip.
         if self.text_widget and event.widget is self.text_widget:
-            print(f"[handle_keypress] EXIT: event from text_widget, skipping")
+            _debug_print(f"[handle_keypress] EXIT: event from text_widget, skipping")
             return
         if event.keysym == "F5":
-            print(f"[handle_keypress] F5 detected, reloading script")
+            _debug_print(f"[handle_keypress] F5 detected, reloading script")
             self.reload_script()
             return
 
-        print(f"[handle_keypress] Calling _process_key")
+        _debug_print(f"[handle_keypress] Calling _process_key")
         self._process_key(event)
-        print(f"[handle_keypress] EXIT")
+        _debug_print(f"[handle_keypress] EXIT")
 
     def _process_key(self, event: tk.Event[tk.Misc]) -> None:
         """Core line-editing logic — shared by widget and global paths."""
         keysym: str = event.keysym
         char: str = event.char or ""
 
-        print(f"[_process_key] ENTRY: keysym={keysym!r} char={char!r} _processing_key={self._processing_key}")
+        _debug_print(f"[_process_key] ENTRY: keysym={keysym!r} char={char!r} _processing_key={self._processing_key}")
 
         if self._processing_key:
-            print(f"[_process_key] EXIT: re-entrance guard blocked")
+            _debug_print(f"[_process_key] EXIT: re-entrance guard blocked")
             return  # Already processing a key, prevent re-entrance
 
         if not self._line_editor:
-            print(f"[_process_key] EXIT: no line editor")
+            _debug_print(f"[_process_key] EXIT: no line editor")
             return
 
         process_info = self.process_tracker.processes.get(self.tab_id)
         if not process_info:
-            print(f"[_process_key] EXIT: no process info")
+            _debug_print(f"[_process_key] EXIT: no process info")
             return
 
         self._processing_key = True
-        print(f"[_process_key] SET _processing_key=True")
+        _debug_print(f"[_process_key] SET _processing_key=True")
         try:
             if keysym == "BackSpace":
-                print(f"[_process_key] Processing BackSpace")
+                _debug_print(f"[_process_key] Processing BackSpace")
                 self._line_editor.backspace()
 
             elif keysym == "Delete":
-                print(f"[_process_key] Processing Delete")
+                _debug_print(f"[_process_key] Processing Delete")
                 self._line_editor.delete()
 
             elif keysym == "Left":
-                print(f"[_process_key] Processing Left")
+                _debug_print(f"[_process_key] Processing Left")
                 self._line_editor.move_left()
 
             elif keysym == "Right":
-                print(f"[_process_key] Processing Right")
+                _debug_print(f"[_process_key] Processing Right")
                 self._line_editor.move_right()
 
             elif keysym == "Home":
-                print(f"[_process_key] Processing Home")
+                _debug_print(f"[_process_key] Processing Home")
                 self._line_editor.move_home()
 
             elif keysym == "End":
-                print(f"[_process_key] Processing End")
+                _debug_print(f"[_process_key] Processing End")
                 self._line_editor.move_end()
 
             elif keysym == "Return":
-                print(f"[_process_key] Processing Return")
+                _debug_print(f"[_process_key] Processing Return")
                 line = self._line_editor.get_line()
-                print(f"[_process_key] Sending line to stdin: {line!r}")
+                _debug_print(f"[_process_key] Sending line to stdin: {line!r}")
                 try:
                     process_info["stdin_queue"].put_nowait(line + "\n")
                 except queue.Full:
                     self.insert_output("[WARNING] Input queue is full. Input dropped.\n")
 
             elif char and char.isprintable():
-                print(f"[_process_key] Processing printable char: {char!r}")
+                _debug_print(f"[_process_key] Processing printable char: {char!r}")
                 self._line_editor.insert_char(char)
             else:
-                print(f"[_process_key] No action taken for this key")
+                _debug_print(f"[_process_key] No action taken for this key")
         finally:
             self._processing_key = False
-            print(f"[_process_key] EXIT: SET _processing_key=False")
+            _debug_print(f"[_process_key] EXIT: SET _processing_key=False")
 
     def on_tab_activated(self) -> None:
         if self.text_widget and self.text_widget.winfo_exists():


### PR DESCRIPTION
Intercept all Text key events and block direct widget edits.

Buffer user input 'line' state in LineEditor.

Echo buffer at end of Text using a named mark, keeping the caret aligned to buffer cursor

On Enter, finalize echo and enqueue the completed line to the subprocess stdin queue

Preserve/restore the echo around stdout/stderr inserts so output appears above in-progress input.

This fixes issue of backspace and other edits not working as expected on input() use.